### PR TITLE
Adam UI changes to prevent lockups

### DIFF
--- a/Makefile.adam
+++ b/Makefile.adam
@@ -3,6 +3,12 @@ TARGET_EXEC ?= autorun.ddp
 BUILD_DIR ?= ./build
 SRC_DIRS ?= ./src
 
+ADDL_DIR1 := ../eoslib/src
+ADDL_DIR2 := ../smartkeyslib/src
+
+ADDL_LIB1 := ../eoslib/eos.lib
+ADDL_LIB2 := ../smartkeyslib/smartkeys.lib
+
 CC=zcc
 AS=zcc
 
@@ -10,8 +16,8 @@ SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.asm)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-CFLAGS=+coleco -subtype=adam -DBUILD_ADAM
-LDFLAGS=+coleco -subtype=adam -m -s -pragma-redirect:CRT_FONT=_font_8x8_coleco_adam_system -o$(TARGET_EXEC) -create-app -lsmartkeys -leos
+CFLAGS=+coleco -subtype=adam -DBUILD_ADAM -I$(ADDL_DIR1) -I$(ADDL_DIR2) -v
+LDFLAGS=+coleco -subtype=adam -pragma-redirect:CRT_FONT=_font_8x8_coleco_adam_system -o$(TARGET_EXEC) -create-app -l$(ADDL_LIB1) -l$(ADDL_LIB2)
 ASFLAGS=+coleco -subtype=adam
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)

--- a/src/adam/screen.c
+++ b/src/adam/screen.c
@@ -43,6 +43,11 @@ void screen_init(void)
   eos_start_read_keyboard();
 }
 
+void screen_debug(char *message)
+{
+  gotoxy(0,0); cprintf(message); 
+}
+
 void screen_error(const char *c)
 {
   smartkeys_display(NULL,NULL,NULL,NULL,NULL,NULL);
@@ -156,11 +161,14 @@ void screen_hosts_and_devices(HostSlot *h, DeviceSlot *d)
   msx_vfill_v(MODE2_ATTR+0x0C00,0xF4,32);
 }
 
+// shown on initial screen
 void screen_hosts_and_devices_hosts(void)
 {
-  smartkeys_display(NULL,NULL,NULL,"  SHOW\n CONFIG","  EDIT\n  SLOT","  BOOT");
+  bool slot_1_occupied = deviceSlots[0].file[0] != 0x00;
+
+  smartkeys_display(NULL,NULL,NULL,"  SHOW\n CONFIG","  EDIT\n  SLOT",slot_1_occupied ? " SLOT 1\n   BOOT" : NULL);
   smartkeys_status("  [RETURN] SELECT HOST\n  [1-8] SELECT SLOT\n  [TAB] GO TO DISK SLOTS");
-  bar_clear();
+  bar_clear(false);
   bar_set(0,1,8,0);
 }
 
@@ -168,7 +176,7 @@ void screen_hosts_and_devices_devices(void)
 {
   smartkeys_display(NULL,NULL,NULL," EJECT","  READ\n  ONLY","  READ\n WRITE");
   smartkeys_status("  [TAB] GO TO HOST SLOTS");
-  bar_clear();
+  bar_clear(false);
   bar_set(11,1,4,0);
 }
 
@@ -181,7 +189,7 @@ void screen_hosts_and_devices_clear_host_slot(unsigned char i)
 void screen_hosts_and_devices_edit_host_slot(unsigned char i)
 {
   smartkeys_display(NULL,NULL,NULL,NULL,NULL,NULL);
-  sprintf(response,"  EDIT THE HOST NAME FOR SLOT %u\n  PRESS [RETURN] WHEN DONE.",i);
+  sprintf(response,"  EDIT THE HOST NAME FOR SLOT %u\n  PRESS [RETURN] WHEN DONE.",i+1);
   smartkeys_status(response);
 }
 
@@ -266,10 +274,14 @@ void screen_select_file_display_entry(unsigned char y, char* e)
   cprintf("%-30s",e);
 }
 
+// Shown on directory screen
 void screen_select_file_choose(char visibleEntries)
 {
+  bool slot_1_occupied = deviceSlots[0].file[0] != 0x00;
+
   bar_set(2,2,visibleEntries,0); // TODO: Handle previous
-  smartkeys_display(NULL,NULL,NULL,(strcmp(path,"/") == 0) ? NULL: "   UP"," FILTER","  BOOT");
+
+  smartkeys_display(NULL,NULL,NULL,(strcmp(path,"/") == 0) ? NULL: "   UP"," FILTER", slot_1_occupied ? " SLOT 1\n BOOT" : "  QUICK\n  BOOT");
   smartkeys_status("  SELECT FILE TO MOUNT\n  [INSERT] CREATE NEW\n  [ESC] ABORT");
 }
 

--- a/src/hosts_and_devices.c
+++ b/src/hosts_and_devices.c
@@ -91,20 +91,23 @@ void hosts_and_devices_hosts(void)
 	case '8':
 	  bar_jump(k-0x31);
 	  break;
-	case 0x09:
+	case 0x09: // TAB
 	  bar_clear(false);
 	  subState=HD_DEVICES;
 	  break;
-	case 0x0d:
+	case 0x0d: // RETURN
 	  selected_host_slot=bar_get();
-	  strcpy(selected_host_name,hostSlots[selected_host_slot]);
-	  subState=HD_DONE;
-	  state=SELECT_FILE;
+	  if (hostSlots[selected_host_slot][0] != 0)
+	  {
+	  	strcpy(selected_host_name,hostSlots[selected_host_slot]);
+	  	subState=HD_DONE;
+	  	state=SELECT_FILE;
+	  }
 	  break;
-	case 0x1b:
+	case 0x1b: // ESC
 	  quit();
 	  break;
-	case 0x84:
+	case 0x84: // 
 	  subState=HD_DONE;
 	  state=SHOW_INFO;
 	  break;


### PR DESCRIPTION
On initial screen, don't show the boot smartkey if there is nothing to boot, otherwise show Slot 1 Boot
When in a directory, show 'Quick Boot' unless there is something in slot 1, then show 'Slot 1 Boot'
fujinet-config-adam:  Changed makefile to collect libs from approprate build directory
Don't attempt to open a Host if the slot is empty
