### PR TITLE
Fix PC88 build by removing EOS include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 obj
+build
+autorun
+*.bin
+*.cas
+*.d88

--- a/src/pc8801/screen.c
+++ b/src/pc8801/screen.c
@@ -10,7 +10,6 @@
 #include "bar.h"
 #include <conio.h>
 #include <sys/ioctl.h>
-#include <eos.h>
 #include <string.h>
 
 extern bool copy_mode;


### PR DESCRIPTION
While I was still in the fixing mood from the Apple II changes earlier today, I figured I would go by and check out the PC-6001 and PC-8801 builds. I assume that these will get further out of date as more and more improvements are made on the ADAM version, but at least this will help a little.

## Changes
The PC-8801 `screen.c` included `eos.h` from the ADAM distribution, which it didn't need to do and was not able to do.

Also updated gitignore to avoid checking in some kinds of binary products (d88, cas, build directory) by mistake.